### PR TITLE
fix docs link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ See examples/vl53l1x_simpletest.py for basic usage example.
 Documentation
 =============
 
-API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/neopixel/en/latest/>`_.
+API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/vl53l1x/en/latest/>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.


### PR DESCRIPTION
This change fixes the docs link near the bottom the readme, it was previously pointing to the neopixel docs instead of VL53L1X