### PR TITLE
Add range status check

### DIFF
--- a/adafruit_vl53l1x.py
+++ b/adafruit_vl53l1x.py
@@ -48,6 +48,7 @@ _SD_CONFIG__WOI_SD0 = const(0x0078)
 _SD_CONFIG__INITIAL_PHASE_SD0 = const(0x007A)
 _SYSTEM__INTERRUPT_CLEAR = const(0x0086)
 _SYSTEM__MODE_START = const(0x0087)
+_VL53L1X_RESULT__RANGE_STATUS = const(0x0089)
 _VL53L1X_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0 = const(0x0096)
 _VL53L1X_IDENTIFICATION__MODEL_ID = const(0x010F)
 
@@ -201,6 +202,8 @@ class VL53L1X:
     @property
     def distance(self):
         """The distance in units of centimeters."""
+        if self._read_register(_VL53L1X_RESULT__RANGE_STATUS)[0] != 0x09:
+            return None
         dist = self._read_register(
             _VL53L1X_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0, 2
         )


### PR DESCRIPTION
Simple fix for #7.

The `distance` will now return `None` if range status is anything other than "valid".

```python
VL53L1X Simple Test.
--------------------
Model ID: 0xEA
Module Type: 0xCC
Mask Revision: 0x10
Distance Mode: SHORT
Timing Budget: 100
--------------------
Distance: None cm
Distance: None cm
Distance: None cm
Distance: None cm
Distance: 14.0 cm
Distance: 18.2 cm
Distance: 33.1 cm
Distance: 46.3 cm
Distance: 25.2 cm
Distance: 9.9 cm
Distance: None cm
Distance: None cm
Distance: None cm
```

For now, check is simple and hard coded. In the future, could expand this out to check for other fail modes and report them back in some manor. Note that the values defined for status:

![image](https://user-images.githubusercontent.com/8755041/170736604-8902da64-5749-435b-93e0-e1f8e795c458.png)

are **not** the same value as the register. See mapping in switch statement here:
https://github.com/adafruit/Adafruit_VL53L1X/blob/f2aaac89649823876451751a43cd1b036d65b22f/src/vl53l1x_class.cpp#L600-L644

That was used to determine that `0x09` register value is `0` range status, aka, `VL53L1_RANGESTATUS_RANGE_VALID`.
